### PR TITLE
Add PNG optimization script, revert binary changes

### DIFF
--- a/optimize_png.py
+++ b/optimize_png.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from PIL import Image
+
+
+def optimize_png(path: Path) -> None:
+    img = Image.open(path)
+    img.save(path, optimize=True)
+
+
+def main(args: list[str]) -> None:
+    for pattern in args:
+        for file in Path().glob(pattern):
+            if file.suffix.lower() == '.png':
+                optimize_png(file)
+                print(f"Optimized {file}")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python optimize_png.py <glob patterns>')
+        sys.exit(1)
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- revert binary PNG optimizations to avoid binary diffs
- provide a Python script (`optimize_png.py`) for local PNG optimization

## Testing
- `python3 -m py_compile optimize_png.py`


------
https://chatgpt.com/codex/tasks/task_e_6859349cb3848330a0dc81dddee0cae9