### PR TITLE
Add legal policy pages and cookie banner

### DIFF
--- a/accessibility-statement/index.html
+++ b/accessibility-statement/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Accessibility Statement - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Accessibility Statement</h2>
+    <p>Jake Fieldhouse Consulting Ltd is committed to ensuring that our website and services are accessible to everyone, including those with disabilities. If you encounter any difficulties using our site or require information in a different format, please contact us at jke.contact.me@gmail.com or call 07400052962, and we will do our best to assist you.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/adr-statement/index.html
+++ b/adr-statement/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Alternative Dispute Resolution Statement - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Alternative Dispute Resolution (ADR) Statement</h2>
+    <p>We aim to resolve all complaints amicably and professionally. If a dispute cannot be resolved, you may be offered referral to a recognised Alternative Dispute Resolution (ADR) provider in line with consumer law and best practice.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/complaints-policy/index.html
+++ b/complaints-policy/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Complaints Policy - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Complaints Policy</h2>
+    <p>Last updated: 11 July 2025</p>
+    <p>Jake Fieldhouse Consulting Ltd aims to deliver high standards of service.</p>
+    <h3>How to Complain</h3>
+    <p>Email your complaint to: jke.contact.me@gmail.com</p>
+    <p>We will acknowledge receipt within 3 working days.</p>
+    <p>We will investigate and aim to respond in writing within 14 days.</p>
+    <p>If you are not satisfied with our response, you may request further review by a company director.</p>
+    <p>If you remain dissatisfied and your complaint relates to data privacy, you may refer it to the Information Commissioner's Office (ICO): <a href="https://ico.org.uk/">https://ico.org.uk/</a></p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/cookie-banner.js
+++ b/cookie-banner.js
@@ -1,0 +1,14 @@
+window.addEventListener('DOMContentLoaded', function () {
+  var banner = document.getElementById('cookie-banner');
+  if (!banner) return;
+  if (!localStorage.getItem('cookieConsent')) {
+    banner.style.display = 'flex';
+  }
+  var btn = document.getElementById('cookie-accept');
+  if (btn) {
+    btn.addEventListener('click', function () {
+      localStorage.setItem('cookieConsent', 'true');
+      banner.style.display = 'none';
+    });
+  }
+});

--- a/cookie-policy/index.html
+++ b/cookie-policy/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Cookie Policy - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Cookie Policy</h2>
+    <p>Last updated: 11 July 2025</p>
+    <p>Jake Fieldhouse Consulting Ltd uses cookies and similar technologies on this website.</p>
+    <h3>What Are Cookies?</h3>
+    <p>Cookies are small text files stored on your device to enable website functionality and analytics.</p>
+    <h3>Types of Cookies We Use</h3>
+    <ul>
+      <li>Strictly Necessary: Essential for basic operation of the website.</li>
+      <li>Analytics/Performance: Help us understand site usage (e.g., Google Analytics).</li>
+      <li>Functionality: Remember your settings and preferences.</li>
+      <li>Marketing: May be used for remarketing or advertising (with consent).</li>
+    </ul>
+    <h3>Consent</h3>
+    <p>Where required by law, you will be shown a cookie consent banner and can opt in or out of non-essential cookies.</p>
+    <h3>Managing Cookies</h3>
+    <p>You can change your preferences at any time using the cookie banner or via your browser settings. Disabling cookies may affect website functionality.</p>
+    <h3>Cookie Duration</h3>
+    <p>Some cookies are deleted when you close your browser ("session cookies"); others remain until they expire or are deleted ("persistent cookies").</p>
+    <h3>Contact</h3>
+    <p>For questions about our use of cookies, contact jke.contact.me@gmail.com or call 07400052962.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/cybersecurity-statement/index.html
+++ b/cybersecurity-statement/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Cybersecurity Statement - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Cybersecurity Statement</h2>
+    <p>Jake Fieldhouse Consulting Ltd adheres to industry best practices for information security and data protection. All client data is treated as confidential and is protected using strong technical and organisational measures. Devices and systems are only accessed as necessary to deliver agreed services, and client information is never disclosed to third parties without consent or legal obligation.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/diversity-inclusion-statement/index.html
+++ b/diversity-inclusion-statement/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Diversity & Inclusion Statement - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Diversity & Inclusion Statement</h2>
+    <p>We are committed to maintaining an inclusive, respectful, and diverse working environment. Jake Fieldhouse Consulting Ltd welcomes clients, partners, and staff from all backgrounds, and does not tolerate discrimination on any grounds.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/dpa-summary/index.html
+++ b/dpa-summary/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Data Processing Agreement (DPA) - Summary</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Data Processing Agreement (DPA) – Summary</h2>
+    <p>Where Jake Fieldhouse Consulting Ltd processes personal data on behalf of clients, we act as a Data Processor in accordance with the UK GDPR.</p>
+    <ul>
+      <li>Personal data is processed only on the documented instructions of the client (Data Controller).</li>
+      <li>We ensure appropriate confidentiality, integrity, and security of personal data.</li>
+      <li>Sub-processors (if used) will be bound by equivalent terms.</li>
+      <li>Data is not transferred outside the UK/EEA without safeguards.</li>
+      <li>Data subject rights and cooperation with clients in handling requests are ensured.</li>
+      <li>Data is deleted or returned on request or contract end.</li>
+      <li>Breaches will be reported promptly.</li>
+    </ul>
+    <p>A full DPA contract can be provided on request.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/environmental-social-responsibility/index.html
+++ b/environmental-social-responsibility/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Environmental & Social Responsibility - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Environmental & Social Responsibility Statement</h2>
+    <p>We strive to operate in an environmentally responsible manner. Jake Fieldhouse Consulting Ltd minimises waste, uses energy efficiently, and seeks to reduce our carbon footprint. We are committed to ethical, fair, and responsible business practices in all that we do.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,25 @@
         <div class="scroll-text">Scroll or Swipe</div>
         <div class="scroll-arrow"></div>
     </div>
+    <div id="cookie-banner">
+        This site uses cookies and may collect personal data to enhance your experience.
+        By using our site, you agree to our <a href="privacy-policy/">Privacy Policy</a>.
+        <button id="cookie-accept">Got it</button>
+    </div>
+    <footer id="site-footer">
+        <nav class="footer-nav">
+            <ul>
+                <li><a href="privacy-policy/">Privacy Policy</a></li>
+                <li><a href="terms-and-conditions/">Terms and Conditions</a></li>
+                <li><a href="cookie-policy/">Cookie Policy</a></li>
+                <li><a href="website-disclaimer/">Website Disclaimer</a></li>
+                <li><a href="complaints-policy/">Complaints Policy</a></li>
+                <li><a href="refund-cancellation-policy/">Refund &amp; Cancellation Policy</a></li>
+            </ul>
+        </nav>
+        <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+    </footer>
     <script src="main.js" defer></script>
+    <script src="cookie-banner.js" defer></script>
 </body>
 </html>

--- a/modern-slavery-statement/index.html
+++ b/modern-slavery-statement/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Modern Slavery Statement - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Modern Slavery Statement</h2>
+    <p>Jake Fieldhouse Consulting Ltd is committed to acting ethically and with integrity in all business relationships and to implementing and enforcing effective systems and controls to ensure modern slavery and human trafficking are not taking place anywhere in our business or supply chains.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/policy-revision-log/index.html
+++ b/policy-revision-log/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Policy Revision Log - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Policy Revision Log</h2>
+    <p>Revision History:</p>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+      <li>[Future updates can be added here]</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/policy.css
+++ b/policy.css
@@ -1,0 +1,77 @@
+:root {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-accent: #007bff;
+}
+body {
+  margin: 0;
+  padding: 20px;
+  font-family: 'Inter', sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+.site-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+.site-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--color-accent);
+}
+main {
+  max-width: 800px;
+  margin: 0 auto;
+}
+footer {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #333;
+  text-align: center;
+  font-size: 0.875rem;
+}
+footer a {
+  color: var(--color-accent);
+}
+.footer-nav ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  padding: 0;
+  margin: 0 0 10px 0;
+}
+.footer-nav a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+#cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #222;
+  color: #fff;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  padding: 15px;
+  font-size: 0.9rem;
+  z-index: 1000;
+}
+#cookie-banner a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  margin: 0 5px;
+}
+#cookie-banner button {
+  margin-left: 10px;
+  padding: 5px 10px;
+  background: var(--color-accent);
+  border: none;
+  color: #000;
+  cursor: pointer;
+}

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Privacy Policy - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Privacy Policy</h2>
+    <p>Last updated: 11 July 2025</p>
+    <p>Jake Fieldhouse Consulting Ltd ("we", "us", or "our") is committed to protecting your privacy and processing your personal data in accordance with the UK General Data Protection Regulation (UK GDPR) and the Data Protection Act 2018.</p>
+    <h3>1. What Information We Collect</h3>
+    <p>We may collect and process: Name, email address, phone number, postal address; Payment and transaction details; Technical data (IP address, browser type/version, device info); Usage data and cookies; Information you provide when contacting us or using our services.</p>
+    <h3>2. Lawful Bases for Processing</h3>
+    <p>We process your personal data with your consent, as necessary for the performance of a contract, to comply with legal obligations, and for our legitimate interests.</p>
+    <h3>3. How We Use Your Information</h3>
+    <p>We use your information to provide, manage, and improve our services, process payments, communicate with you, meet legal obligations, and with consent send marketing communications.</p>
+    <h3>4. Sharing Your Information</h3>
+    <p>We may share your information with service providers, legal authorities if required, and other parties with your explicit consent. We do not sell your personal data.</p>
+    <h3>5. International Data Transfers</h3>
+    <p>If we transfer data outside the UK/EEA, we ensure appropriate safeguards are in place.</p>
+    <h3>6. Data Security</h3>
+    <p>We use appropriate technical and organisational measures to protect your data from unauthorised access, loss, or disclosure.</p>
+    <h3>7. Data Retention</h3>
+    <p>We retain your data only as long as necessary and securely delete or anonymise data when no longer required.</p>
+    <h3>8. Your Rights</h3>
+    <p>You have rights to access, rectify, erase, restrict or object to processing, data portability, withdraw consent, and lodge a complaint with the ICO. Contact jke.contact.me@gmail.com to exercise your rights.</p>
+    <h3>9. Cookies</h3>
+    <p>See our <a href="../cookie-policy/">Cookie Policy</a>.</p>
+    <h3>10. Changes to This Policy</h3>
+    <p>We may update this policy. Check this page for updates.</p>
+    <h3>11. Contact Us</h3>
+    <p>If you have any questions or concerns, contact jke.contact.me@gmail.com or call 07400052962.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/refund-cancellation-policy/index.html
+++ b/refund-cancellation-policy/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Refund & Cancellation Policy - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Refund & Cancellation Policy</h2>
+    <p>Last updated: 11 July 2025</p>
+    <h3>Consumer Right to Cancel</h3>
+    <p>If you are a consumer and have booked services online, you have the right to cancel within 14 days of booking, under the Consumer Contracts Regulations 2013. If you request that we begin work within this 14-day period, you may lose your right to a full refund for work already performed.</p>
+    <h3>Service Cancellations</h3>
+    <p>You may cancel a booking up to 24 hours before the scheduled time for a full refund. Cancellations after this period may incur a fee.</p>
+    <h3>Refunds</h3>
+    <p>Refunds will be processed within 7 days of cancellation or if a service cannot be provided as agreed. No refunds are given for completed services, unless required by law.</p>
+    <h3>Contact</h3>
+    <p>For refund or cancellation requests, contact jke.contact.me@gmail.com or call 07400052962.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/service-level-commitment/index.html
+++ b/service-level-commitment/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Service Level Commitment - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Service Level Commitment</h2>
+    <p>Jake Fieldhouse Consulting Ltd aims to respond to all client enquiries within one business day. For ongoing support contracts or urgent IT incidents, we will provide a clear target response and resolution time based on your requirements. Custom Service Level Agreements are available for clients with specific needs.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -338,3 +338,55 @@ body::before {
     height: 30px;
   }
 }
+
+/* Footer and legal links */
+#site-footer {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #333;
+  text-align: center;
+  font-size: 0.9rem;
+}
+.footer-nav ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  padding: 0;
+  margin: 0 0 10px 0;
+}
+.footer-nav a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+/* Cookie banner */
+#cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #222;
+  color: #fff;
+  padding: 15px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  z-index: 1000;
+}
+#cookie-banner a {
+  color: var(--color-accent);
+  margin: 0 5px;
+  text-decoration: underline;
+}
+#cookie-banner button {
+  margin-left: 10px;
+  padding: 5px 10px;
+  background: var(--color-accent);
+  border: none;
+  color: #000;
+  cursor: pointer;
+}

--- a/terms-and-conditions/index.html
+++ b/terms-and-conditions/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Terms and Conditions - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Terms and Conditions</h2>
+    <p>Last updated: 11 July 2025</p>
+    <p>Welcome to Jake Fieldhouse Consulting Ltd ("we", "us"). By using our website or engaging our services, you ("you", "the client") accept these Terms and Conditions.</p>
+    <h3>Services</h3>
+    <p>We provide business and IT consulting, support, repairs, and related services, subject to acceptance of your enquiry or booking.</p>
+    <h3>Formation of Contract</h3>
+    <p>A binding contract forms when you accept a quotation, complete a booking, or instruct us to proceed with services.</p>
+    <h3>Bookings & Payment</h3>
+    <p>We may require bookings and advance payment for certain services. Full details are provided at the time of booking.</p>
+    <h3>Cancellations & Refunds</h3>
+    <p>See our <a href="../refund-cancellation-policy/">Refund & Cancellation Policy</a>.</p>
+    <h3>Consumer Rights</h3>
+    <p>Nothing in these terms affects your statutory rights under UK consumer law.</p>
+    <h3>Liability</h3>
+    <p>To the fullest extent permitted by law, we exclude all liability for indirect, special, or consequential loss or damage. Our total liability for any claim shall not exceed the amount paid for the relevant service. We do not exclude or limit liability for death or personal injury caused by our negligence, fraud, or any liability which cannot legally be excluded.</p>
+    <h3>Intellectual Property</h3>
+    <p>All content and materials on this site or provided as part of services are our property or licensed to us. You may not reproduce or distribute our materials without our written permission.</p>
+    <h3>Privacy</h3>
+    <p>See our <a href="../privacy-policy/">Privacy Policy</a>.</p>
+    <h3>Website Use</h3>
+    <p>You agree not to misuse this website, introduce viruses, or attempt unauthorised access.</p>
+    <h3>Changes</h3>
+    <p>We may update these terms. Continued use of our services constitutes acceptance of changes.</p>
+    <h3>Governing Law and Jurisdiction</h3>
+    <p>These terms are governed by English law. Disputes will be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/testimonials/index.html
+++ b/testimonials/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Client Testimonials - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Client Testimonials / Case Studies</h2>
+    <blockquote>
+      <p>“Jake Fieldhouse Consulting went above and beyond to fix our systems and deliver a custom solution. Responsive, knowledgeable, and easy to work with.”</p>
+      <footer>– Operations Manager, <em>[Company Name, optional]</em></footer>
+    </blockquote>
+    <p><em>Additional testimonials and case studies can be added here.</em></p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/website-disclaimer/index.html
+++ b/website-disclaimer/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Website Disclaimer - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Website Disclaimer</h2>
+    <p>Last updated: 11 July 2025</p>
+    <p>The information on this website is for general informational purposes only and does not constitute professional, financial, or legal advice. Always consult a qualified professional before taking action.</p>
+    <p>While we endeavour to keep information accurate and up-to-date, we make no warranties, express or implied, regarding completeness, accuracy, reliability, or availability.</p>
+    <p>We are not liable for any loss or damage, direct or indirect, arising from use of this site.</p>
+    <p>External links: We are not responsible for content or availability of external websites linked from this site.</p>
+    <p>We do not guarantee that the website will be uninterrupted, secure, or free from errors or viruses.</p>
+    <h3>Policy Revision Log</h3>
+    <ul>
+      <li>11 July 2025 – Initial publication</li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create policy.css for policy pages and add cookie banner styles
- implement cookie-banner.js for consent storage
- embed cookie banner and legal links in index footer
- add comprehensive policy pages with revision logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871292490b48330bdae754954def052