### PR TITLE
Fix meta image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
     <meta name="keywords" content="Jake Fieldhouse, IT Professional, Hardware Specialist, AI Advocate, Resume, CV">
     <meta property="og:title" content="Jake Fieldhouse - IT Professional">
     <meta property="og:description" content="Jake Fieldhouse - IT Professional, Hardware Specialist, AI Advocate">
-    <meta property="og:image" content="images/github.png">
+    <meta property="og:image" content="https://jake-fieldhouse.github.io/me/images/github.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Jake Fieldhouse - IT Professional">
     <meta name="twitter:description" content="Jake Fieldhouse - IT Professional, Hardware Specialist, AI Advocate">
-    <meta name="twitter:image" content="images/github.png">
+    <meta name="twitter:image" content="https://jake-fieldhouse.github.io/me/images/github.png">
     <title>Jake Fieldhouse - IT Professional</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- update meta tags to use hosted image URL

## Testing
- `python3 -m http.server 8000` and curl page

------
https://chatgpt.com/codex/tasks/task_e_687799e53384833088aee7e4d1de3d6d