### PR TITLE
Add meta descriptions to policy pages

### DIFF
--- a/accessibility-statement/index.html
+++ b/accessibility-statement/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Accessibility Statement: Jake Fieldhouse Consulting aims for a website usable by everyone. Contact us for assistance or alternate formats, and we'll help.">
   <title>Accessibility Statement - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/adr-statement/index.html
+++ b/adr-statement/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Jake Fieldhouse Consulting seeks to resolve complaints professionally. If unresolved, we may refer you to a recognised Alternative Dispute Resolution provider.">
   <title>Alternative Dispute Resolution Statement - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/complaints-policy/index.html
+++ b/complaints-policy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Our Complaints Policy explains how to raise concerns with Jake Fieldhouse Consulting, the response timeframe, and escalation options if you're not satisfied.">
   <title>Complaints Policy - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/cookie-policy/index.html
+++ b/cookie-policy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Understand how Jake Fieldhouse Consulting uses cookies and similar technologies, the types we use, and how you can manage your preferences on this website.">
   <title>Cookie Policy - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/cybersecurity-statement/index.html
+++ b/cybersecurity-statement/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Jake Fieldhouse Consulting's Cybersecurity Statement shows how we protect client data with technical controls and secure access to ensure confidentiality.">
   <title>Cybersecurity Statement - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/diversity-inclusion-statement/index.html
+++ b/diversity-inclusion-statement/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Jake Fieldhouse Consulting embraces diversity and inclusion. We strive for a respectful workplace, welcoming all backgrounds and rejecting discrimination.">
   <title>Diversity & Inclusion Statement - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/dpa-summary/index.html
+++ b/dpa-summary/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Summary of our DPA. Jake Fieldhouse Consulting's duties when processing client data under UK GDPR include confidentiality and secure transfers for all clients.">
   <title>Data Processing Agreement (DPA) - Summary</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/environmental-social-responsibility/index.html
+++ b/environmental-social-responsibility/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Jake Fieldhouse Consulting's Environmental and Social Responsibility Statement details our commitment to minimize waste, save energy, and act ethically.">
   <title>Environmental & Social Responsibility - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/modern-slavery-statement/index.html
+++ b/modern-slavery-statement/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Our Modern Slavery Statement outlines Jake Fieldhouse Consulting's commitment to prevent slavery and human trafficking in our business and supply chains.">
   <title>Modern Slavery Statement - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/policy-revision-log/index.html
+++ b/policy-revision-log/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Track changes to Jake Fieldhouse Consulting policies. This revision log lists publication dates and notes future updates for transparency and accountability.">
   <title>Policy Revision Log - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Learn how Jake Fieldhouse Consulting collects, uses and safeguards your personal data under UK GDPR and the Data Protection Act 2018, plus your rights.">
   <title>Privacy Policy - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/refund-cancellation-policy/index.html
+++ b/refund-cancellation-policy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Read our Refund and Cancellation Policy to learn about consumer rights, cancelling bookings, and how refunds are processed at Jake Fieldhouse Consulting.">
   <title>Refund & Cancellation Policy - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/service-level-commitment/index.html
+++ b/service-level-commitment/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Jake Fieldhouse Consulting's Service Level Commitment promises replies within one business day and custom SLAs for clients who need specific response times.">
   <title>Service Level Commitment - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/terms-and-conditions/index.html
+++ b/terms-and-conditions/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="These Terms and Conditions explain how Jake Fieldhouse Consulting provides IT consulting services, forms contracts, and handles bookings and payments.">
   <title>Terms and Conditions - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/testimonials/index.html
+++ b/testimonials/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Read client testimonials showing how Jake Fieldhouse Consulting delivered responsive, knowledgeable service and custom solutions. More stories will follow.">
   <title>Client Testimonials - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/website-disclaimer/index.html
+++ b/website-disclaimer/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Read how Jake Fieldhouse Consulting limits liability for website content and links. External sites are not endorsed, and no warranties are provided today.">
   <title>Website Disclaimer - Jake Fieldhouse Consulting Ltd</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add meta description tags to policy pages like privacy-policy, cookie-policy and more

## Testing
- `grep -n "meta name=\"description\"" privacy-policy/index.html`


------
https://chatgpt.com/codex/tasks/task_e_687799eb8d888330ba106d87e119db8f