### PR TITLE
Enable non-JS view for content sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
     <link rel="icon" href="images/github.png" type="image/png">
     <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body class="no-js">
+    <noscript>
+        <div class="no-js-message">Please enable JavaScript to see animations.</div>
+    </noscript>
     <main id="main-container">
         <section id="intro-section">
             <header id="main-heading">

--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@
 
 // Wrap everything in an IIFE to avoid polluting the global scope
 (function () {
+    document.body.classList.remove('no-js');
+    document.body.classList.add('js-enabled');
     // ---------------------- Element Selection ----------------------
     const elements = document.querySelectorAll('.title-line');
     const totalSteps = elements.length * 2 + 1; // Adjusted total steps

--- a/styles.css
+++ b/styles.css
@@ -126,6 +126,16 @@ body::before {
 
 /* Content sections */
 .content-section {
+  max-height: none;
+  overflow: visible;
+  opacity: 1;
+  margin: var(--spacing-sm) 0;
+  padding: 0;
+  font-size: 1.5vw;
+  line-height: 1.6;
+}
+
+body.js-enabled .content-section {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
@@ -133,11 +143,8 @@ body::before {
     max-height 1s ease-in-out,
     opacity 1s ease-in-out;
   margin: 0;
-  padding: 0;
-  font-size: 1.5vw;
-  line-height: 1.6;
 }
-.content-section.visible {
+body.js-enabled .content-section.visible {
   max-height: 500px; /* Adjust as needed */
   opacity: 1;
   margin: var(--spacing-sm) 0;
@@ -365,4 +372,12 @@ body::before {
   border: none;
   color: #000;
   cursor: pointer;
+}
+
+/* Message shown when JavaScript is disabled */
+.no-js-message {
+  background: #ff7ad9;
+  color: #000;
+  padding: 10px;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- default `.content-section` blocks to be visible when JavaScript is disabled
- hide the sections via `.js-enabled` class when JavaScript runs
- display a small notice if JavaScript is disabled

## Testing
- `grep -n "<<<<<<<\|=======\|>>>>>>>" -R .`

------
https://chatgpt.com/codex/tasks/task_e_68779a1f54788330a16540c929839a22