### PR TITLE
Add services info, corporate policies index, and SEO updates

### DIFF
--- a/corporate-policies/index.html
+++ b/corporate-policies/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="description" content="Browse the full set of corporate policies for Jake Fieldhouse Consulting Ltd.">
+  <title>Corporate Policies - Jake Fieldhouse Consulting Ltd</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../policy.css">
+</head>
+<body>
+  <header class="site-header"><h1>Jake Fieldhouse Consulting Ltd</h1></header>
+  <main>
+    <h2>Corporate Policies</h2>
+    <ul>
+      <li><a href="../privacy-policy/">Privacy Policy</a></li>
+      <li><a href="../terms-and-conditions/">Terms and Conditions</a></li>
+      <li><a href="../cookie-policy/">Cookie Policy</a></li>
+      <li><a href="../website-disclaimer/">Website Disclaimer</a></li>
+      <li><a href="../complaints-policy/">Complaints Policy</a></li>
+      <li><a href="../refund-cancellation-policy/">Refund &amp; Cancellation Policy</a></li>
+      <li><a href="../accessibility-statement/">Accessibility Statement</a></li>
+      <li><a href="../modern-slavery-statement/">Modern Slavery Statement</a></li>
+      <li><a href="../environmental-social-responsibility/">Environmental &amp; Social Responsibility</a></li>
+      <li><a href="../cybersecurity-statement/">Cybersecurity Statement</a></li>
+      <li><a href="../diversity-inclusion-statement/">Diversity &amp; Inclusion Statement</a></li>
+      <li><a href="../dpa-summary/">DPA Summary</a></li>
+      <li><a href="../service-level-commitment/">Service Level Commitment</a></li>
+      <li><a href="../adr-statement/">ADR Statement</a></li>
+      <li><a href="../policy-revision-log/">Policy Revision Log</a></li>
+    </ul>
+  </main>
+  <footer>
+    <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>
+  </footer>
+  <div id="cookie-banner">
+    This site uses cookies and may collect personal data to enhance your experience.
+    By using our site, you agree to our <a href="../privacy-policy/">Privacy Policy</a>.
+    <button id="cookie-accept">Got it</button>
+  </div>
+  <script src="../cookie-banner.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,10 +5,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="description" content="Jake Fieldhouse - IT Professional, Hardware Specialist, AI Advocate">
-    <meta name="keywords" content="Jake Fieldhouse, IT Professional, Hardware Specialist, AI Advocate, Resume, CV">
+    <meta name="keywords" content="Jake Fieldhouse, IT Professional, Hardware Specialist, AI Advocate, Resume, CV, IT Support, Consulting, Repair Services, Digital Marketing">
+    <meta name="author" content="Jake Fieldhouse Consulting Ltd">
+    <meta name="robots" content="index, follow">
     <meta property="og:title" content="Jake Fieldhouse - IT Professional">
     <meta property="og:description" content="Jake Fieldhouse - IT Professional, Hardware Specialist, AI Advocate">
     <meta property="og:image" content="https://jake-fieldhouse.github.io/me/images/github.png">
+    <meta property="og:url" content="https://jake-fieldhouse.github.io/me/">
+    <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Jake Fieldhouse - IT Professional">
     <meta name="twitter:description" content="Jake Fieldhouse - IT Professional, Hardware Specialist, AI Advocate">
@@ -47,6 +51,15 @@
             <div id="content-ai-advocate" class="content-section">
                 <p>Enthusiastic about artificial intelligence and its potential to transform industries.</p>
                 <p>Actively exploring AI applications to enhance business processes.</p>
+            </div>
+            <div id="services" class="content-section">
+                <h3>Our Services</h3>
+                <ul>
+                    <li>IT Support &amp; Consulting</li>
+                    <li>Repair Services</li>
+                    <li>Digital Marketing</li>
+                </ul>
+                <p><a href="testimonials/">Read client testimonials</a></p>
             </div>
         </section>
     </main>
@@ -88,6 +101,7 @@
                 <li><a href="website-disclaimer/">Website Disclaimer</a></li>
                 <li><a href="complaints-policy/">Complaints Policy</a></li>
                 <li><a href="refund-cancellation-policy/">Refund &amp; Cancellation Policy</a></li>
+                <li><a href="corporate-policies/">Corporate Policies</a></li>
             </ul>
         </nav>
         <p>Jake Fieldhouse Consulting Ltd | <a href="https://jake-fieldhouse.github.io/me/">https://jake-fieldhouse.github.io/me/</a> | Company No. 16536646</p>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://jake-fieldhouse.github.io/me/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/privacy-policy/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/terms-and-conditions/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/cookie-policy/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/website-disclaimer/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/complaints-policy/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/refund-cancellation-policy/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/accessibility-statement/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/modern-slavery-statement/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/environmental-social-responsibility/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/cybersecurity-statement/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/diversity-inclusion-statement/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/dpa-summary/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/service-level-commitment/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/adr-statement/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/testimonials/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/policy-revision-log/</loc></url>
+  <url><loc>https://jake-fieldhouse.github.io/me/corporate-policies/</loc></url>
+</urlset>

--- a/styles.css
+++ b/styles.css
@@ -382,3 +382,14 @@ body::before {
   color: #000;
   cursor: pointer;
 }
+
+/* Services section */
+#services ul {
+  list-style: disc inside;
+  margin: var(--spacing-sm) 0;
+  padding-left: 1em;
+}
+
+#services a {
+  color: var(--color-accent);
+}


### PR DESCRIPTION
## Summary
- expand SEO metadata
- add services section with testimonial link
- link to new corporate policies page
- style services list
- include sitemap and corporate policies list page

## Testing
- `python3 -m py_compile optimize_png.py`

------
https://chatgpt.com/codex/tasks/task_e_6878acf20f988330a5e283ba23f33487